### PR TITLE
Omnibus amendment

### DIFF
--- a/constitution.md
+++ b/constitution.md
@@ -340,7 +340,7 @@ Amendments that only include stylistic, grammatical, typographical, graphical, o
 
 #### Section 5 - Interpretation of Bylaws
 
-These bylaws are to be interpreted by the Executive.
+These bylaws are to be interpreted by the Executive, except that Article 4 Section 4 shall be interpreted by the Executive as directed by the Board.
 
 #### Section 6 - Conflicts with UWSA Policy
 

--- a/constitution.md
+++ b/constitution.md
@@ -335,7 +335,7 @@ If notice is so given, then the Secretary or other member who recieves such noti
 - In the case of a reinstatement without dismissal of the removal order, the Board may order the unsealing of the minutes from the meeting to remove the member, and if the unsealing is refused by the member, the Board may deny reinstatement and dismiss the appeal.
 
 
-#### Section 4 - Removal at General or Regular Meeting
+#### Section 5 - Removal at General or Regular Meeting
 
 Any Board or Executive Member at a Regular Meeting of CSS may call for the removal of any Executive Member for the reason of a lack of confidence in that member to discharge the duties properly: 
 - Such a call may be confirmed by a *simple-majority* of the Board, or disposed of by the same. The member in question may have that portion of the minutes sealed under the same procedure as for ordinary removal meetings. 
@@ -345,7 +345,7 @@ Any Member of the Society may at a General Meeting call for the removal of any E
 - Such a call may be confirmed by a *three-fifths* majority of the membership of that General Meeting, provided that general meeting has quorum, or may be disposed of by a *simple-majority*.
 - If the call is neither confirmed nor disposed of during the general meeting, then the Board may call a special meeting with the person who so makes the request, and confirm or dispose of it as though a call made by a Board member at a Regular Meeting to remove an Executive, but if the call is not confirmed during that meeting it is disposed of at its adjournment. If the Board does not call such a Special Meeting, then the call is disposed of.
 
-#### Section 5 - Constitutional Amendments
+#### Section 6 - Constitutional Amendments
 
 The constitution can be amended at a regular meeting, or a general
 meeting, with a three-fourths majority vote.
@@ -354,24 +354,24 @@ Any amendments must be announced one week prior to either meeting.
 
 Amendments that only include stylistic, grammatical, typographical, graphical, or formatting changes can be made to the constitution outside of a meeting, without the need for an announcement one week prior, with a three-fourths majority vote. This vote may be electronic or in-person, as decided by the President.  
 
-#### Section 6 - Interpretation of Bylaws
+#### Section 7 - Interpretation of Bylaws
 
 These bylaws are to be interpreted by the Executive, except that Article 4 Section 4 shall be interpreted by the Executive as directed by the Board.
 
-#### Section 7 - Conflicts with UWSA Policy
+#### Section 8 - Conflicts with UWSA Policy
 
 Nothing in this instrument shall be read to contradict UWSA rules
 regarding clubs or societies. In the event where a contradiction shall
 occur, the rules of the UWSA shall have precedent.
 
-#### Section 8 - Parliamentary Authority
+#### Section 9 - Parliamentary Authority
 
 The rules contained in the current edition of Robert's Rules of Order
 Newly Revised shall govern CSS in all cases to which they are applicable
 and in which they are not inconsistent with these bylaws and any special
 rules of order CSS may adopt.
 
-#### Section 9 - Resignations
+#### Section 10 - Resignations
 
 An executive member may resign from their position by submitting a
 written notice to the Executive at least two weeks in advance. The

--- a/constitution.md
+++ b/constitution.md
@@ -295,6 +295,7 @@ In the event that a **member** is not fulfilling their responsibilities, the fol
 2. If, after one week, the **member** is still not found to be fulfilling their responsibilities, the **President** shall issue a written warning.
 3. After an additional week, if the **member** is still not found to be fulfilling their responsibilities, a meeting will be called to determine whether the individual will retain their position.
 
+
 _**Note:** In the event the **member** in question is the **President**, the **Vice President** will conduct the above procedure._
 
 #### Section 3 - Meeting to Remove an Executive or Council Member
@@ -310,8 +311,12 @@ they should continue to hold their position.
 - Quorum for the meeting shall be all of the **executives**, not including the accused.
 - If quorum is not met, or in the event that a **two-thirds vote** is
 not obtained, the individual shall retain their position.
-- No minutes shall be published for this meeting, beyond the immediate
-result.
+- At the sole request of the **member** in question, the minutes shall be sealed and shall not be published, beyond the immediate result. Such a request may be made up to the meeting, or at any point before minutes are routinely published. 
+    - The President or some other executive _shall_ inform the **member** in question of the right to seal publication of the minutes.
+    - If the **member** in question is the President, then the Vice President has the responsibility to inform the President of this right.
+    - If the **member** in question shall not request the minutes be so sealed after being dutifully informed, then the minutes *shall* be published as routinely done so for Executive Meetings. The same applies of the **member** explicitly requests the minutes be published or explicitly waives the right to seal the minutes.
+    - The **member** in question may, for a reasonable period of time following the meeting, request or permit the minutes to be unsealed in which case they shall be published as routinely done so for Executive Meetings.
+
 
 #### Section 4 - Constitutional Amendments
 

--- a/constitution.md
+++ b/constitution.md
@@ -311,11 +311,12 @@ they should continue to hold their position.
 - Quorum for the meeting shall be all of the **executives**, not including the accused.
 - If quorum is not met, or in the event that a **two-thirds vote** is
 not obtained, the individual shall retain their position.
-- At the sole request of the **member** in question, the minutes shall be sealed and shall not be published, beyond the immediate result. Such a request may be made up to the meeting, or at any point before minutes are routinely published. 
-    - The President or some other executive _shall_ inform the **member** in question of the right to seal publication of the minutes.
+- Except at the sole request of the **member** in question, the minutes shall be sealed and shall not be published, beyond the immediate result and a notice that the minutes were sealed.
+    - The President or some other executive _shall_ inform the **member** in question of the right to unseal publication of the minutes.
     - If the **member** in question is the President, then the Vice President has the responsibility to inform the President of this right.
-    - If the **member** in question shall not request the minutes be so sealed after being dutifully informed, then the minutes *shall* be published as routinely done so for Executive Meetings. The same applies of the **member** explicitly requests the minutes be published or explicitly waives the right to seal the minutes.
+    - If the **member** in question shall request the minutes not be so sealed after being dutifully informed, then the minutes *shall* be published as routinely done so for Executive Meetings.
     - The **member** in question may, for a reasonable period of time following the meeting, request or permit the minutes to be unsealed in which case they shall be published as routinely done so for Executive Meetings.
+    - The **member** in question may explicitly request the minutes be sealed, in which case, they shall be sealed just the same.
 
 
 #### Section 4 - Constitutional Amendments

--- a/constitution.md
+++ b/constitution.md
@@ -321,7 +321,7 @@ Any Board or Executive Member at a Regular Meeting of CSS may call for the remov
 
 Any Member of the Society may at a General Meeting call for the removal of any Executive or Board Member, except for the CSC Liason, for the reason of a lack of confidence in that member to discharge their duties properly:
 - Such a call may be confirmed by a *three-fifths* majority of the membership of that General Meeting, provided that general meeting has quorum, or may be disposed of by a *simple-majority*.
-- If the call is neither confirmed nor disposed of during the general meeting, then the Board may call a special meeting with the person who so makes the request, and confirm or dispose of it as though a call made by a Board member at a Regular Meeting, but if the call is not confirmed during that meeting it is disposed of at its adjournment. If the Board does not call such a Special Meeting, then the call is disposed of
+- If the call is neither confirmed nor disposed of during the general meeting, then the Board may call a special meeting with the person who so makes the request, and confirm or dispose of it as though a call made by a Board member at a Regular Meeting to remove an Executive, but if the call is not confirmed during that meeting it is disposed of at its adjournment. If the Board does not call such a Special Meeting, then the call is disposed of.
 
 #### Section 5 - Constitutional Amendments
 

--- a/constitution.md
+++ b/constitution.md
@@ -294,6 +294,7 @@ In the event that a **member** is not fulfilling their responsibilities, the fol
 1. The **President** will meet with the **member** to discuss concerns raised by the membership.
 2. If, after one week, the **member** is still not found to be fulfilling their responsibilities, the **President** shall issue a written warning.
 3. After an additional week, if the **member** is still not found to be fulfilling their responsibilities, a meeting will be called to determine whether the individual will retain their position.
+4. If the **member** is removed at such a meeting, they may appeal within a reasonable period to the CSS Board, as prescribed in Section 4.
 
 _**Note:** In the event the **member** in question is the **President**, the **Vice President** will conduct the above procedure._
 
@@ -312,6 +313,21 @@ they should continue to hold their position.
 not obtained, the individual shall retain their position.
 - No minutes shall be published for this meeting, beyond the immediate
 result.
+
+#### Section 4 - Appeals of Removals
+
+A **member** removed by the Process prescribed in Section 2 may, within a reasonable period of time prescribed by the Board but not lesser than 15 days, appeal to the Board by notice in writing or some other manner acceptable to the Board to the Secretary, or if there is no Secretary, to either the Head of Development, the Senior Representative, or any First or Second Year Representative. 
+
+If notice is so given, then the Secretary or other member who recieves such notice shall inform the President and the remainder of the Board, which shall consider the appeal at either the next Regular Meeting or at a Special Meeting convened for that purpose, at least 1 week after reciept of such notice, but no later than 3 weeks without the consent of that **member**. 
+
+- The **member** shall be invited to attend the meeting, but shall have no vote during such. 
+- Prior to such meeting, the Executive shall deliver to the Board the Minutes from the meeting to remove the member, notwithstand any seal put in place at request of the **member**.
+- During the meeting, the Board may, by simple-majority, dismiss the appeal or allow the appeal. If the appeal is dimissed, then the removal order is confirmed. If the appeal is allowed, then the Board may do any of the following at its option:
+    - Dismiss the Removal Order and reinstate the member,
+    - Affirm the Removal Order but reinstate the member notwithstanding the removal order,
+    - Reverse the Removal Order and remand to continued consideration by the Executive, with any instructions the Board sees fit to issue that the Executive _shall_ consider
+- In the case of a reinstatement without dismissal of the removal order, the Board may order the unsealing of the minutes from the meeting to remove the member, and if the unsealing is refused by the member, the Board may deny reinstatement and dismiss the appeal.
+
 
 #### Section 4 - Constitutional Amendments
 

--- a/constitution.md
+++ b/constitution.md
@@ -316,7 +316,7 @@ result.
 
 #### Section 4 - Appeals of Removals
 
-A **member** removed by the Process prescribed in Section 2 may, within a reasonable period of time prescribed by the Board but not lesser than 15 days, appeal to the Board by notice in writing or some other manner acceptable to the Board to the Secretary, or if there is no Secretary, to either the Head of Development, the Senior Representative, or any First or Second Year Representative. 
+A **member** removed by the Process prescribed in Section 2 may, within a reasonable period of time prescribed by the Board but not lesser than 15 days, appeal to the Board by notice in writing or some other manner acceptable to the Board to the Secretary, or if there is no Secretary, to either the Head of Technology, the Senior Representative, or any First or Second Year Representatives. 
 
 If notice is so given, then the Secretary or other member who recieves such notice shall inform the President and the remainder of the Board, which shall consider the appeal at either the next Regular Meeting or at a Special Meeting convened for that purpose, at least 1 week after reciept of such notice, but no later than 3 weeks without the consent of that **member**. 
 

--- a/constitution.md
+++ b/constitution.md
@@ -313,7 +313,17 @@ not obtained, the individual shall retain their position.
 - No minutes shall be published for this meeting, beyond the immediate
 result.
 
-#### Section 4 - Constitutional Amendments
+#### Section 4 - Removal at General or Regular Meeting
+
+Any Board or Executive Member at a Regular Meeting of CSS may call for the removal of any Executive Member for the reason of a lack of confidence in that member to discharge the duties properly: 
+- Such a call may be confirmed by a *simple-majority* of the Board, or disposed of by the same. The member in question may have that portion of the minutes sealed under the same procedure as for ordinary removal meetings. 
+- A call made during one Regular meeting need not be confirmed or dimissed during that meeting, and may be confirmed or disposed of at a later meeting.
+
+Any Member of the Society may at a General Meeting call for the removal of any Executive or Board Member, except for the CSC Liason, for the reason of a lack of confidence in that member to discharge their duties properly:
+- Such a call may be confirmed by a *three-fifths* majority of the membership of that General Meeting, provided that general meeting has quorum, or may be disposed of by a *simple-majority*.
+- If the call is neither confirmed nor disposed of during the general meeting, then the Board may call a special meeting with the person who so makes the request, and confirm or dispose of it as though a call made by a Board member at a Regular Meeting, but if the call is not confirmed during that meeting it is disposed of at its adjournment. If the Board does not call such a Special Meeting, then the call is disposed of
+
+#### Section 5 - Constitutional Amendments
 
 The constitution can be amended at a regular meeting, or a general
 meeting, with a three-fourths majority vote.
@@ -322,24 +332,24 @@ Any amendments must be announced one week prior to either meeting.
 
 Amendments that only include stylistic, grammatical, typographical, graphical, or formatting changes can be made to the constitution outside of a meeting, without the need for an announcement one week prior, with a three-fourths majority vote. This vote may be electronic or in-person, as decided by the President.  
 
-#### Section 5 - Interpretation of Bylaws
+#### Section 6 - Interpretation of Bylaws
 
 These bylaws are to be interpreted by the Executive.
 
-#### Section 6 - Conflicts with UWSA Policy
+#### Section 7 - Conflicts with UWSA Policy
 
 Nothing in this instrument shall be read to contradict UWSA rules
 regarding clubs or societies. In the event where a contradiction shall
 occur, the rules of the UWSA shall have precedent.
 
-#### Section 7 - Parliamentary Authority
+#### Section 8 - Parliamentary Authority
 
 The rules contained in the current edition of Robert's Rules of Order
 Newly Revised shall govern CSS in all cases to which they are applicable
 and in which they are not inconsistent with these bylaws and any special
 rules of order CSS may adopt.
 
-#### Section 8 - Resignations
+#### Section 9 - Resignations
 
 An executive member may resign from their position by submitting a
 written notice to the Executive at least two weeks in advance. The

--- a/constitution.md
+++ b/constitution.md
@@ -316,12 +316,12 @@ result.
 
 #### Section 4 - Appeals of Removals
 
-A **member** removed by the Process prescribed in Section 2 may, within a reasonable period of time prescribed by the Board but not lesser than 15 days, appeal to the Board by notice in writing or some other manner acceptable to the Board to the Secretary, or if there is no Secretary, to either the Head of Technology, the Senior Representative, or any First or Second Year Representatives. 
+A **member** removed by the Process prescribed in Section 2 may, within a reasonable period of time prescribed by the Board but not lesser than 7 days, appeal to the Board by notice in writing or some other manner acceptable to the Board to the Secretary, or if there is no Secretary, to either the Head of Student Affairs, the Senior Representative, or any First or Second Year Representatives. 
 
 If notice is so given, then the Secretary or other member who recieves such notice shall inform the President and the remainder of the Board, which shall consider the appeal at either the next Regular Meeting or at a Special Meeting convened for that purpose, at least 1 week after reciept of such notice, but no later than 3 weeks without the consent of that **member**. 
 
 - The **member** shall be invited to attend the meeting, but shall have no vote during such. 
-- Prior to such meeting, the Executive shall deliver to the Board the Minutes from the meeting to remove the member, notwithstand any seal put in place at request of the **member**.
+- Prior to such meeting, the Executive shall deliver to the Board the Minutes from the meeting to remove the member, notwithstanding any seal put in place **member**.
 - During the meeting, the Board may, by simple-majority, dismiss the appeal or allow the appeal. If the appeal is dimissed, then the removal order is confirmed. If the appeal is allowed, then the Board may do any of the following at its option:
     - Dismiss the Removal Order and reinstate the member,
     - Affirm the Removal Order but reinstate the member notwithstanding the removal order,

--- a/constitution.md
+++ b/constitution.md
@@ -324,7 +324,7 @@ If notice is so given, then the Secretary or other member who recieves such noti
 - Prior to such meeting, the Executive shall deliver to the Board the Minutes from the meeting to remove the member, notwithstanding any seal put in place **member**.
 - During the meeting, the Board may, by simple-majority, dismiss the appeal or allow the appeal. If the appeal is dimissed, then the removal order is confirmed. If the appeal is allowed, then the Board may do any of the following at its option:
     - Dismiss the Removal Order and reinstate the member,
-    - Affirm the Removal Order but reinstate the member notwithstanding the removal order,
+    - Affirm the Removal Order but reinstate the member notwithstanding the removal order, possibly with such conditions as the Board may deem proper in the totality of the circumstances,
     - Reverse the Removal Order and remand to continued consideration by the Executive, with any instructions the Board sees fit to issue that the Executive _shall_ consider
 - In the case of a reinstatement without dismissal of the removal order, the Board may order the unsealing of the minutes from the meeting to remove the member, and if the unsealing is refused by the member, the Board may deny reinstatement and dismiss the appeal.
 


### PR DESCRIPTION
Contains 3 Amendments to the CSS Constitution concerning removal of Members, as follows:
* Optional unsealing of minutes from meeting to remove a member,
* Appeal of a removal order to the Board, and
* The ability for the Board to remove an Executive, and for the general membership to remove an Executive or Board Member by reason of no confidence.

This is intended to be approved by a 3/4s majority vote at the upcoming General Meeting of CSS.